### PR TITLE
Solving an issue where mdl-option with value 0 is not selected

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -91,7 +91,10 @@ export class MdlSelectComponent implements ControlValueAccessor {
         if (this.multiple) {
             this.text = value.map((value: string) => this.textByValue[String(value)]).join(', ');
         } else {
-            this.text = !!value ? this.textByValue[String(value)] : '';
+            this.text =
+              (!!value || typeof value === 'number')
+              ? this.textByValue[String(value)]
+              : '';
         }
         this.changeDetectionRef.detectChanges();
 


### PR DESCRIPTION
In the example below, mdl-select is generated with no selected option ( blank select area ):
```Typescript
import { Component } from '@angular/core';

@Component({
  selector: 'select-test',
  template: `
    <mdl-select [(ngModel)]="selectedOption">
      <mdl-option value="0">This is not being selected</mdl-option>
      <mdl-option value="1">Some other option</mdl-option>
    </mdl-select>
  `
})
export class SelectTestComponent {
  public selectedOption: number = 0;
  constructor() {}
}

```