### PR TITLE
Bug Fix - Deselect already set object value on 'mdl-select'

### DIFF
--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -420,8 +420,18 @@ describe('MdlSelect', () => {
                     expect(selectComponentInstance.ngModel)
                       .toEqual( [arrWith3Obj[0], arrWith3Obj[1]], 'did not update ngModel on deselect 3');
 
+                    selectComponentInstance.onSelect(event, arrWith3Obj[1]);
+
+                    fixture.detectChanges();
+                    fixture.whenStable().then(() => {
+
+                    expect(selectComponentInstance.ngModel)
+                      .toEqual( [arrWith3Obj[0]], 'did not update ngModel on deselect 3');
+
+                    });
                 });
 
+                
             });
 
         }));

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -276,8 +276,8 @@ export class MdlSelectComponent extends SearchableComponent implements ControlVa
                 // skip ngModel update when undefined value or multiple selects initialized with same array
             } else if (Array.isArray(value)) {
                 this.ngModel = uniq(this.ngModel.concat(value));
-            } else if (this.ngModel.indexOf(value) != -1) {
-                this.ngModel = [...this.ngModel.filter((v: string) => v !== value)];
+            } else if (this.ngModel.map((v:any) => this.stringifyValue(v)).indexOf(this.stringifyValue(value)) != -1) {
+                this.ngModel = [...this.ngModel.filter((v: any) => this.stringifyValue(v) !== this.stringifyValue(value))];
             } else if (!!value) {
                 this.ngModel = [...this.ngModel, value];
             }

--- a/src/e2e-app/app/select/select.component.html
+++ b/src/e2e-app/app/select/select.component.html
@@ -147,18 +147,21 @@
 <p>
   FormControl return array of coordinate object as value
 </p>
-
-<mdl-select [(ngModel)]="locations" multiple="true" placeholder="Select locations">
-  <mdl-option *ngFor="let c of cityCoordinates" [value]="{ latitude: c.latitude , longitude: c.longitude }">{{ c.name }}</mdl-option>
-</mdl-select>
+<form [formGroup]="arrayForm">
+  <mdl-select [(ngModel)]="locations" formControlName="locations" multiple="true" placeholder="Select locations">
+    <mdl-option *ngFor="let c of cityCoordinates" [value]="{ latitude: c.latitude , longitude: c.longitude }">{{ c.name }}</mdl-option>
+  </mdl-select>
+</form>
 <p>
   Locations: {{ locations | json }}
 </p>
 
 <pre prism ngNonBindable>
   <![CDATA[
-<mdl-select [(ngModel)]="locations" multiple="true" placeholder="Select locations">
-  <mdl-option *ngFor="let c of cityCoordinates" [value]="{ latitude: c.latitude , longitude: c.longitude }">{{ c.name }}</mdl-option>
-</mdl-select>
+<form [formGroup]="arrayForm">
+  <mdl-select [(ngModel)]="locations" formControlName="locations" multiple="true" placeholder="Select locations">
+    <mdl-option *ngFor="let c of cityCoordinates" [value]="{ latitude: c.latitude , longitude: c.longitude }">{{ c.name }}</mdl-option>
+  </mdl-select>
+</form>
    ]]>
 </pre>

--- a/src/e2e-app/app/select/select.component.ts
+++ b/src/e2e-app/app/select/select.component.ts
@@ -73,6 +73,9 @@ export class SelectDemo {
   };
   food: string[];
 
+  arrayForm: FormGroup;
+  locationControl = new FormControl('');
+
   cityCoordinates: any = [
     {name: 'İstanbul', latitude:'41.0055005',longitude:'28.7319952'},
     {name: 'Paris', latitude:'48.8589507',longitude:'2.2770202'},
@@ -88,6 +91,23 @@ export class SelectDemo {
     this.form = new FormGroup({
       personId: this.personId
     });
+
+    this.arrayForm = new FormGroup({
+      locations: this.locationControl
+    })
+
+    this.locationControl.valueChanges
+      .subscribe((value: any) => {
+        console.log('locationControl.valueChanges', value);
+      });
+
+    this.locationControl.setValue([
+      {latitude:'41.0055005',longitude:'28.7319952'},
+      {latitude:'37.757815',longitude:'-122.50764'}
+    ]);
+
+    console.log('this.arrayForm.value',this.arrayForm.value);
+
 
     this.personId.valueChanges
       .subscribe((value: any) => {


### PR DESCRIPTION
If you set array of objects as a value on the 'mdl-select' component, you can not deselect these values. 