### PR TITLE
floating label feature fixed for select component

### DIFF
--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -8,9 +8,24 @@
 
 ### Usage example
 
-    <mdl-select [(ngModel)]="personId">
-      <mdl-option *ngFor="let p of people" [value]="p.id">{{p.name}}</mdl-option>
-    </mdl-select>
+```js
+<mdl-select [(ngModel)]="personId">
+    <mdl-option *ngFor="let p of people" [value]="p.id">{{p.name}}</mdl-option>
+</mdl-select>
+```
+#### using placeholder
+```js
+<mdl-select placeholder="Person Name" [(ngModel)]="personId">
+    <mdl-option *ngFor="let p of people" [value]="p.id">{{p.name}}</mdl-option>
+</mdl-select>
+```
+
+#### using label with floating label
+```js
+<mdl-select label="{{personLabel}}" floating-label [(ngModel)]="personId">
+    <mdl-option *ngFor="let p of people" [value]="p.id">{{p.name}}</mdl-option>
+</mdl-select>
+```
 
 ### API Summary
 
@@ -21,6 +36,8 @@
 | `[ngModel]` | any | Select data binding
 | `[disabled]` | boolean | Whether or not the select is disabled
 | `[placeholder]` | string | Placeholder text
+| `[label]` | string | Label text
+| `[floating-label]` | any | If present or true the ```label``` will be floating on ```focus``` event
 | `[multiple]` | boolean | Multiselect mode
 
 #### mdl-option

--- a/src/components/select/select.html
+++ b/src/components/select/select.html
@@ -1,5 +1,5 @@
 <div
-  class="mdl-textfield is-upgraded has-placeholder"
+  class="mdl-textfield is-upgraded"
   [class.is-focused]="this.popoverComponent.isVisible || this.focused"
   [class.is-disabled]="this.disabled"
   [class.is-dirty]="text != null && text.length > 0">
@@ -10,9 +10,9 @@
     <!-- don't want click to also trigger focus -->
   </span>
   <input readonly tabindex="-1"
-      [placeholder]="placeholder"
       class="mdl-textfield__input"
       (click)="toggle($event)"
+      [placeholder]="placeholder ? placeholder : ''"
       [attr.id]="textfieldId"
       [value]="text">
   <span
@@ -20,7 +20,7 @@
       (click)="toggle($event)">
     keyboard_arrow_down
   </span>
-  <label class="mdl-textfield__label" [attr.for]="textfieldId">{{ placeholder }}</label>
+  <label class="mdl-textfield__label" [attr.for]="textfieldId">{{ label }}</label>
   <span class="mdl-textfield__error"></span>
   <mdl-popover hide-on-click="!multiple" [style.width.%]="100">
     <div class="mdl-list mdl-shadow--6dp">

--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -35,6 +35,19 @@ describe('MdlSelect', () => {
             });
         }));
 
+        it('should support floating-label attr', async(() => {
+
+            let selectComponent = fixture.debugElement.query(By.directive(MdlSelectComponent));
+
+            let selectNativeElement = selectComponent.nativeElement;
+
+            expect(selectNativeElement.classList.contains('mdl-select--floating-label'))
+                .toBe(true, 'did not has css class mdl-select--floating-label')
+
+            expect(selectComponent.nativeElement.querySelector('.mdl-textfield__label').innerText)
+                .toBe(selectComponent.componentInstance.label, 'did not set correct label text');
+        }));
+
 
         it('should create the component and add the mdl-select css class', async(() => {
 
@@ -463,13 +476,14 @@ describe('MdlSelect', () => {
 @Component({
     selector: 'test-single-component',
     template: `
-        <mdl-select [(ngModel)]="personId">
+        <mdl-select label="{{label}}" floating-label [(ngModel)]="personId">
           <mdl-option *ngFor="let p of people" [value]="p.id">{{p.name}}</mdl-option>
         </mdl-select>
     `
 })
 class TestSingleComponent {
     personId: number = 1;
+    label: string = 'floating label';
     people: any[] = [
         {id: 1, name: 'Bryan Cranston'},
         {id: 2, name: 'Aaron Paul'},

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -20,6 +20,10 @@ import { MdlOptionComponent } from './option';
 
 const uniq = (array: any[]) => Array.from(new Set(array));
 
+function toBoolean (value:any): boolean {
+  return value != null && `${value}` !== 'false';
+}
+
 function randomId() {
     const S4 = () => (((1+Math.random())*0x10000)|0).toString(16).substring(1);
     return (S4()+S4());
@@ -62,7 +66,8 @@ export class SearchableComponent {
     selector: 'mdl-select',
     host: {
         '[class.mdl-select]': 'true',
-        '[class.mdl-select--floating-label]': 'isFloatingLabel != null'
+        '[class.mdl-select--floating-label]': 'isFloatingLabel',
+        '[class.has-placeholder]': 'placeholder'
     },
     templateUrl: 'select.html',
     encapsulation: ViewEncapsulation.None,
@@ -71,12 +76,16 @@ export class SearchableComponent {
 export class MdlSelectComponent extends SearchableComponent implements ControlValueAccessor {
     @Input() ngModel: any;
     @Input() disabled: boolean = false;
-    @Input('floating-label') public isFloatingLabel: any;
+    @Input() public label: string = '';
+    @Input('floating-label')
+    get isFloatingLabel() { return this._isFloatingLabel; }
+    set isFloatingLabel(value) { this._isFloatingLabel = toBoolean(value); }
     @Input() placeholder: string = '';
     @Input() multiple: boolean = false;
     @Output() private change: EventEmitter<any> = new EventEmitter(true);
     @ViewChild(MdlPopoverComponent) public popoverComponent: MdlPopoverComponent;
     @ContentChildren(MdlOptionComponent) public optionComponents: QueryList<MdlOptionComponent>;
+    private _isFloatingLabel: boolean = false;
     private textfieldId: string;
     private text: string = '';
     private textByValue: any = {};
@@ -294,10 +303,6 @@ export class MdlSelectComponent extends SearchableComponent implements ControlVa
 
     public registerOnTouched(fn: () => {}): void {
         this.onTouched = fn;
-    }
-
-    public getLabelVisibility(): string {
-        return this.isFloatingLabel == null || (this.isFloatingLabel != null && this.text != null && this.text.length > 0) ? "block" : "none";
     }
 }
 

--- a/src/e2e-app/app/select/select.component.html
+++ b/src/e2e-app/app/select/select.component.html
@@ -18,31 +18,31 @@
    ]]>
 </pre>
 
-<h5>ngModel with placeholder (no initial value) and floating label</h5>
+<h5>ngModel with floating label</h5>
 
 <h6>without initial value</h6>
-<mdl-select floating-label [(ngModel)]="otherCountryCode" placeholder="Country">
+<mdl-select label="{{countryLabel}}" floating-label [(ngModel)]="otherCountryCode">
   <mdl-option *ngFor="let c of countries" [value]="c.code">{{c.name}}</mdl-option>
 </mdl-select>
 
 <pre prism ngNonBindable>
   <![CDATA[
-<mdl-select floating-label [(ngModel)]="otherCountryCode" placeholder="Country">
+<mdl-select label="{{countryLabel}}" floating-label [(ngModel)]="otherCountryCode">
   <mdl-option *ngFor="let c of countries" [value]="c.code">{{c.name}}</mdl-option>
 </mdl-select>
    ]]>
 </pre>
 
-<h6>without initial value, with nullable option</h6>
+<h6>without initial value, with nullable option and placeholder</h6>
 <p>By setting an option with a blank value, the select field will revert back to the placeholder text (similar to a textfield).</p>
-<mdl-select floating-label [(ngModel)]="otherCountryCode2" placeholder="Country">
+<mdl-select [(ngModel)]="otherCountryCode2" placeholder="Country">
   <mdl-option [value]=""><em>-- Select a Country --</em></mdl-option>
   <mdl-option *ngFor="let c of countries" [value]="c.code">{{c.name}}</mdl-option>
 </mdl-select>
 
 <pre prism ngNonBindable>
   <![CDATA[
-<mdl-select floating-label [(ngModel)]="otherCountryCode2" placeholder="Country">
+<mdl-select [(ngModel)]="otherCountryCode2" placeholder="Country">
   <mdl-option [value]=""><em>-- Select a Country --</em></mdl-option>
   <mdl-option *ngFor="let c of countries" [value]="c.code">{{c.name}}</mdl-option>
 </mdl-select>

--- a/src/e2e-app/app/select/select.component.ts
+++ b/src/e2e-app/app/select/select.component.ts
@@ -36,6 +36,7 @@ export class SelectDemo {
   ];
 
   countryCode: string = 'FR';
+  countryLabel: string = 'Country';
   otherCountryCode: string = null;
   otherCountryCode2: string = null;
   countryCodes: string[] = ['FR', 'DE', 'IT'];


### PR DESCRIPTION
Hi, I have just updated select component to work more consistent with approach introduced in mdl-textfield component in addition to label and placeholder managing. The way it works now is:

1. placeholder is applied only for input field (previously it was set to floating label)
2. label input property has been added
3. floating-label works only with label field

So for now we have two options: we can use placeholder or label (optionally with floating-label) as in mdl-textfield component.