### PR TITLE
Fix autoselecting on empty query

### DIFF
--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -297,6 +297,7 @@ describe('MdlSelect', () => {
             spyOn(selectComponentInstance, 'onSelect').and.callThrough();
             spyOn(selectComponentInstance, 'onCharacterKeydown').and.callThrough();
 
+            selectNativeElement.querySelector("span[tabindex]").focus();
             selectNativeElement.querySelector("input").focus();
             fixture.detectChanges();
 
@@ -325,6 +326,7 @@ describe('MdlSelect', () => {
             spyOn(selectComponentInstance, 'onSelect').and.callThrough();
             spyOn(selectComponentInstance, 'onCharacterKeydown').and.callThrough();
 
+            selectNativeElement.querySelector("span[tabindex]").focus();
             selectNativeElement.querySelector("input").focus();
 
             dispatchKeydownEvent(document.body, 66); // 'B' key

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -172,12 +172,17 @@ export class MdlSelectComponent extends SearchableComponent implements ControlVa
     }
 
     private getAutoSelection(): any {
-        let optionsList = this.optionComponents.toArray();
+        const searchQuery = this.getSearchQuery();
+        const optionsList = this.optionComponents.toArray();
         const filteredOptions = optionsList.filter(option => {
-            return option.text.toLowerCase().startsWith(this.getSearchQuery());
+            return option.text.toLowerCase().startsWith(searchQuery);
         });
 
         const selectedOption = optionsList.find(option => option.selected);
+
+        if (!searchQuery) {
+            return null;
+        }
 
         if (filteredOptions.length > 0) {
             const selectedOptionInFiltered = filteredOptions.indexOf(selectedOption) != -1;


### PR DESCRIPTION
![037kwkndqo](https://cloud.githubusercontent.com/assets/71683/25715138/b3610c7a-30fa-11e7-8c2f-c0f5cac37560.gif)

When you blur  autoselect input first option is selected even if you have not typed anything.

I have made in this PR, but could not fix tests :(