### PR TITLE
ExpansionPanelGroup supports panel in initial expanded state

### DIFF
--- a/src/components/expansion-panel/expansion-panel.component.ts
+++ b/src/components/expansion-panel/expansion-panel.component.ts
@@ -145,19 +145,19 @@ export class MdlExpansionPanelComponent implements AfterContentInit, OnInit {
     this._toggle(false);
   }
 
-  _toggle(isExpanded: boolean) {
-    this.isExpanded = isExpanded;
-    this.content.isExpanded = `${isExpanded}`;
-    this.header.isExpanded = isExpanded;
-    this.onChange.emit(isExpanded);
-  }
-
   disableToggle() {
     this.disabled = true;
   }
 
   enableToggle() {
     this.disabled = false;
+  }
+
+  private _toggle(isExpanded: boolean) {
+    this.isExpanded = isExpanded;
+    this.content.isExpanded = `${isExpanded}`;
+    this.header.isExpanded = isExpanded;
+    this.onChange.emit(isExpanded);
   }
 }
 
@@ -173,12 +173,23 @@ export class MdlExpansionPanelGroupComponent implements AfterContentInit {
   expandedIndex: number = -1;
 
   ngAfterContentInit() {
-    /**
-     * Expand the panel and collapse previously
-     * expanded panel.
-     * Save the new expanded panel.
-     */
     this.panels.forEach((panel, i) => {
+      /**
+       * Collapse all panels except the last of all panels which are
+       * initialized in expanded state.
+       */
+      if (panel.expanded) {
+        if (this.expandedIndex > -1) {
+          this.panels.toArray()[this.expandedIndex].collapse();
+        }
+        this.expandedIndex = i;
+      }
+
+      /**
+       * Expand the panel and collapse previously
+       * expanded panel when a panel is toggled.
+       * Save the new expanded panel.
+       */
       panel.onChange.subscribe((isExpanded: boolean) => {
         if (isExpanded) {
           if (i !== this.expandedIndex && this.expandedIndex >= 0) {

--- a/src/components/expansion-panel/expansion-panel.spec.ts
+++ b/src/components/expansion-panel/expansion-panel.spec.ts
@@ -107,6 +107,21 @@ describe('MdlExpansionPanel', () => {
                   .toContain('expanded');
         });
     }));
+
+    it('should allow ONE panel which is initialized in expanded state', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(1)').getAttribute('class'))
+          .not.toContain('expanded');
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(2)').getAttribute('class'))
+          .not.toContain('expanded');
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(3)').getAttribute('class'))
+          .toContain('expanded');
+      });
+    }));
   });
 
 
@@ -156,10 +171,10 @@ describe('MdlExpansionPanel', () => {
 class TestSinglePanelComponent {}
 
 @Component({
-  selector: 'test-component',
+  selector: 'test-group-component',
   template: `
     <mdl-expansion-panel-group #panelGroup>
-      <mdl-expansion-panel *ngFor="let i of [1,2,3]">
+      <mdl-expansion-panel *ngFor="let i of [1,2,3]" [expanded]="true">
         <mdl-expansion-panel-header></mdl-expansion-panel-header>
         <mdl-expansion-panel-content><p>body</p></mdl-expansion-panel-content>
       </mdl-expansion-panel>

--- a/src/components/expansion-panel/expansion-panel.spec.ts
+++ b/src/components/expansion-panel/expansion-panel.spec.ts
@@ -68,18 +68,37 @@ describe('MdlExpansionPanel', () => {
   });
 
   describe('group', () => {
-
     let fixture: ComponentFixture<TestGroupPanelComponent>;
+    let fixtureWithError: ComponentFixture<TestGroupPanelError>;
 
     beforeEach(async(() => {
       TestBed.configureTestingModule({
         imports: [MdlExpansionPanelModule.forRoot(), NoopAnimationsModule],
-        declarations: [TestGroupPanelComponent],
+        declarations: [
+          TestGroupPanelComponent,
+          TestGroupPanelError
+        ],
       });
 
       TestBed.compileComponents().then( () => {
         fixture = TestBed.createComponent(TestGroupPanelComponent);
+        fixtureWithError = TestBed.createComponent(TestGroupPanelError);
         fixture.detectChanges();
+      });
+    }));
+
+    it('should allow one panel which is initialized in expanded state', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(1)').getAttribute('class'))
+          .toContain('expanded');
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(2)').getAttribute('class'))
+          .not.toContain('expanded');
+        expect(fixture.debugElement.nativeElement
+          .querySelector('.mdl-expansion-panel:nth-child(3)').getAttribute('class'))
+          .not.toContain('expanded');
       });
     }));
 
@@ -87,17 +106,10 @@ describe('MdlExpansionPanel', () => {
       fixture
         .debugElement
         .nativeElement
-        .querySelector('.mdl-expansion-panel:nth-child(1) .mdl-expansion-panel__header--expand-icon')
+        .querySelector('.mdl-expansion-panel:nth-child(2) .mdl-expansion-panel__header--expand-icon')
         .click();
       fixture.detectChanges();
       fixture.whenStable()
-        .then(() => {
-          fixture.debugElement.nativeElement
-            .querySelector('.mdl-expansion-panel:nth-child(2) .mdl-expansion-panel__header--expand-icon')
-            .click();
-          fixture.detectChanges();
-          return fixture.whenStable();
-        })
         .then(() => {
           expect(fixture.debugElement.nativeElement
                   .querySelector('.mdl-expansion-panel:nth-child(1)').getAttribute('class'))
@@ -108,20 +120,16 @@ describe('MdlExpansionPanel', () => {
         });
     }));
 
-    it('should allow ONE panel which is initialized in expanded state', async(() => {
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(fixture.debugElement.nativeElement
-          .querySelector('.mdl-expansion-panel:nth-child(1)').getAttribute('class'))
-          .not.toContain('expanded');
-        expect(fixture.debugElement.nativeElement
-          .querySelector('.mdl-expansion-panel:nth-child(2)').getAttribute('class'))
-          .not.toContain('expanded');
-        expect(fixture.debugElement.nativeElement
-          .querySelector('.mdl-expansion-panel:nth-child(3)').getAttribute('class'))
-          .toContain('expanded');
-      });
-    }));
+    it('throws if panel group panels are initialized incorrectly', () => {
+      let error;
+      try {
+        fixtureWithError.detectChanges();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error instanceof Error).toBe(true);
+    })
   });
 
 
@@ -174,7 +182,7 @@ class TestSinglePanelComponent {}
   selector: 'test-group-component',
   template: `
     <mdl-expansion-panel-group #panelGroup>
-      <mdl-expansion-panel *ngFor="let i of [1,2,3]" [expanded]="true">
+      <mdl-expansion-panel *ngFor="let i of [1,2,3]; let isFirst = first" [expanded]="isFirst">
         <mdl-expansion-panel-header></mdl-expansion-panel-header>
         <mdl-expansion-panel-content><p>body</p></mdl-expansion-panel-content>
       </mdl-expansion-panel>
@@ -182,6 +190,19 @@ class TestSinglePanelComponent {}
   `
 })
 class TestGroupPanelComponent {}
+
+@Component({
+  selector: 'test-group-error',
+  template: `
+    <mdl-expansion-panel-group>
+      <mdl-expansion-panel *ngFor="let i of [1,2,3]" [expanded]="true">
+        <mdl-expansion-panel-header></mdl-expansion-panel-header>
+        <mdl-expansion-panel-content><p>body</p></mdl-expansion-panel-content>
+      </mdl-expansion-panel>
+    </mdl-expansion-panel-group>
+  `
+})
+class TestGroupPanelError {}
 
 @Component({
   selector: 'test-host-component',

--- a/src/components/expansion-panel/package.json
+++ b/src/components/expansion-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-mdl/expansion-panel",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Angular 2 Material Design Lite - Extension Panel Component",
   "main": "./index.umd.js",
   "module": "./index.js",

--- a/src/e2e-app/app/expansion-panel/expansion-panel.component.html
+++ b/src/e2e-app/app/expansion-panel/expansion-panel.component.html
@@ -57,7 +57,7 @@
 </section>
 
 <section>
-  <h5>Single expansion panel - expanded initially </h5>
+  <h5>Single expansion panel - expanded initially</h5>
   <mdl-expansion-panel [expanded]="true">
     <mdl-expansion-panel-header>
       <mdl-expansion-panel-header-list-content>Primary Title</mdl-expansion-panel-header-list-content>
@@ -90,7 +90,7 @@
   <h5>Expansion panel group</h5>
   <p>Individual panel in a group can be focused by TAB key. Panels can be toggled by pressing ENTER key when focused.</p>
   <mdl-expansion-panel-group #panelGroup>
-    <mdl-expansion-panel *ngFor="let i of [1,2,3]" [expanded]="true">
+    <mdl-expansion-panel *ngFor="let i of [1,2,3]">
       <mdl-expansion-panel-header>
         <mdl-expansion-panel-header-list-content>Primary Title {{i}}</mdl-expansion-panel-header-list-content>
       </mdl-expansion-panel-header>
@@ -135,6 +135,39 @@
         mdl-ripple
         (click)="panelGroup.getPanel(1).toggle()">Toggle Second</button>
 <div>expanded: {x{panelGroup.getExpanded()}}</div>
+    ]]>
+  </pre>
+</section>
+
+<section>
+  <h5>Expansion panel group - having one panel expanded initially</h5>
+  <p>Note: A Panel Group only supports initialization of ONE panel in expanded state.</p>
+  <mdl-expansion-panel-group>
+    <mdl-expansion-panel *ngFor="let i of [1,2,3]; let isFirst = first" [expanded]="isFirst">
+      <mdl-expansion-panel-header>
+        <mdl-expansion-panel-header-list-content>Primary Title {{i}}</mdl-expansion-panel-header-list-content>
+      </mdl-expansion-panel-header>
+      <mdl-expansion-panel-content>
+        <mdl-expansion-panel-body>
+          <p>This is expansion panel {{i}}</p>
+        </mdl-expansion-panel-body>
+      </mdl-expansion-panel-content>
+    </mdl-expansion-panel>
+  </mdl-expansion-panel-group>
+  <pre prism>
+    <![CDATA[
+<mdl-expansion-panel-group>
+  <mdl-expansion-panel *ngFor="let i of [1,2,3]; let isFirst = first" [expanded]="isFirst">
+    <mdl-expansion-panel-header>
+      <mdl-expansion-panel-header-list-content>Primary Title {x{i}}</mdl-expansion-panel-header-list-content>
+    </mdl-expansion-panel-header>
+    <mdl-expansion-panel-content>
+      <mdl-expansion-panel-body>
+        <p>This is expansion panel {x{i}}</p>
+      </mdl-expansion-panel-body>
+    </mdl-expansion-panel-content>
+  </mdl-expansion-panel>
+</mdl-expansion-panel-group>
     ]]>
   </pre>
 </section>

--- a/src/e2e-app/app/expansion-panel/expansion-panel.component.html
+++ b/src/e2e-app/app/expansion-panel/expansion-panel.component.html
@@ -90,7 +90,7 @@
   <h5>Expansion panel group</h5>
   <p>Individual panel in a group can be focused by TAB key. Panels can be toggled by pressing ENTER key when focused.</p>
   <mdl-expansion-panel-group #panelGroup>
-    <mdl-expansion-panel *ngFor="let i of [1,2,3]">
+    <mdl-expansion-panel *ngFor="let i of [1,2,3]" [expanded]="true">
       <mdl-expansion-panel-header>
         <mdl-expansion-panel-header-list-content>Primary Title {{i}}</mdl-expansion-panel-header-list-content>
       </mdl-expansion-panel-header>


### PR DESCRIPTION
In the previous [Pull Request](https://github.com/mseemann/angular2-mdl-ext/pull/785) the MdlExpansionPanel was updated to accept "expanded" input.

This Pull Request adds support of this expanded state to the MdlExpansionPanelGroup. Since I had problems with ng's ExpressionChangedAfterItHasBeenCheckedError in the karma tests the support is limited to having one panel initialized in expanded state.

Would be great if you could publish the new version of the package to the NPM registry or give me feedback if something should be changed.