### PR TITLE
Hide Popovers with CustomEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@angular/router": "4.2.6",
     "@mseemann/prism": "0.0.1",
     "core-js": "2.4.1",
+    "custom-event-polyfill": "^0.3.0",
     "moment": "^2.18.1",
     "rxjs": "5.4.2",
     "systemjs": "0.20.15",

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -10,6 +10,7 @@ import {
     NgModule,
     ViewEncapsulation
 } from '@angular/core';
+import 'custom-event-polyfill';
 
 
 @Component({
@@ -66,7 +67,7 @@ export class MdlPopoverComponent implements AfterViewInit {
     private hideAllPopovers() {
       let nodeList = document.querySelectorAll('.mdl-popover.is-visible');
       for(let i=0; i < nodeList.length;++i) {
-        nodeList[i].dispatchEvent(new Event('hide'));
+        nodeList[i].dispatchEvent(new CustomEvent('hide'));
       }
     }
 

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -11,7 +11,7 @@
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "outDir": "../tmp/src",
-    "typeRoots": ["./../node_modules/@types"],
+    "typeRoots": ["../../node_modules/@types"],
     "types": [
       "node",
       "jasmine"


### PR DESCRIPTION
Due to lack of event constructor support in IE11, changed the popover component to use CustomEvents and added a custom event polyfill for IE. This lets select boxes work in IE and addresses issue #846 