### PR TITLE
Popover component IE compatibility

### DIFF
--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -86,18 +86,68 @@ describe('MdlPopover', () => {
 
             expect(popoverNativeElement.classList.contains('is-visible'))
               .toBe(true, 'did not has css class is-visible');
-
         });
-
     }));
 
+    it('should toggle popover on another popover opening', async(() => {
+
+        let popoverComponent = fixture.debugElement.query(By.directive(MdlPopoverComponent));
+        let popoverNativeElement = popoverComponent.nativeElement;
+        let buttonNativeElement = fixture.debugElement.query(By.css('button')).nativeElement;
+        let popoverComponentInstance = popoverComponent.componentInstance;
+        let anotherButtonNativeElement = fixture.debugElement.query(By.css('#anotherButton')).nativeElement;
+        let anotherPopoverComponentInstance = fixture.debugElement.query(By.css('#anotherPopover')).componentInstance;
+
+        expect(popoverComponentInstance.isVisible)
+          .toEqual(false, 'isVisible is not false');
+
+        expect(popoverNativeElement.classList.contains('is-visible'))
+          .toBe(false, 'did has css class is-visible');
+
+        spyOn(popoverComponentInstance, 'toggle').and.callThrough();
+
+        spyOn(popoverComponentInstance, 'hideAllPopovers').and.callThrough();
+
+        spyOn(popoverComponentInstance, 'updateDirection').and.callThrough();
+
+        buttonNativeElement.click();
+
+        expect(popoverComponentInstance.toggle).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.hideAllPopovers).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.updateDirection).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.isVisible)
+          .toEqual(true, 'toggle did not update isVisible to true');
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+
+            expect(popoverNativeElement.classList.contains('is-visible'))
+              .toBe(true, 'did not has css class is-visible');
+        });
+
+        let hideAllPopoversSpy = spyOn(anotherPopoverComponentInstance, 'hideAllPopovers').and.callThrough();
+
+        anotherButtonNativeElement.click();
+
+        fixture.whenStable().then(() => {
+            expect(hideAllPopoversSpy).toHaveBeenCalled();
+            expect(anotherPopoverComponentInstance.isVisible).toBe(true, 'second popover did not show');
+            expect(popoverComponentInstance.isVisible).toBe(false, 'main popover did not hide');
+        });
+    }));
 });
 
 @Component({
     selector: 'test-component',
     template: `
-      <button (click)="popover.toggle($event)">button</button>
-      <mdl-popover #popover>popover content</mdl-popover>
+      <button id="mainButton" (click)="popover.toggle($event)">button</button>
+      <mdl-popover id="mainPopover" #popover>popover content</mdl-popover>
+
+      <button (click)="anotherPopover.toggle($event)" id="anotherButton">button</button>
+      <mdl-popover id="anotherPopover" #anotherPopover>fubar</mdl-popover>
     `
 })
 class TestComponent {}

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -66,9 +66,7 @@ export class MdlPopoverComponent implements AfterViewInit {
     private hideAllPopovers() {
       let nodeList = document.querySelectorAll('.mdl-popover.is-visible');
       for(let i=0; i < nodeList.length;++i) {
-          let event = document.createEvent('CustomEvent');
-          event.initCustomEvent('hide', false, false, {});
-          nodeList[i].dispatchEvent(event);
+          nodeList[i].dispatchEvent(new CustomEvent('hide'));
       }
     }
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -66,7 +66,9 @@ export class MdlPopoverComponent implements AfterViewInit {
     private hideAllPopovers() {
       let nodeList = document.querySelectorAll('.mdl-popover.is-visible');
       for(let i=0; i < nodeList.length;++i) {
-        nodeList[i].dispatchEvent(new Event('hide'));
+          let event = document.createEvent('CustomEvent');
+          event.initCustomEvent('hide', false, false, {});
+          nodeList[i].dispatchEvent(event);
       }
     }
 

--- a/src/e2e-app/polyfills.ts
+++ b/src/e2e-app/polyfills.ts
@@ -9,3 +9,16 @@ if (process.env['ENV'] === 'production') {
   Error['stackTraceLimit'] = Infinity;
   require('zone.js/dist/long-stack-trace-zone');
 }
+
+(function () {
+  function CustomEvent ( event, params ) {
+    params = params || { bubbles: false, cancelable: false, detail: undefined };
+    var evt:CustomEvent = <any>document.createEvent( 'CustomEvent' );
+    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+    return evt;
+   };
+
+  CustomEvent.prototype = Event.prototype;
+
+  (<any>window).CustomEvent = <any>CustomEvent;
+})();

--- a/src/e2e-app/polyfills.ts
+++ b/src/e2e-app/polyfills.ts
@@ -9,16 +9,3 @@ if (process.env['ENV'] === 'production') {
   Error['stackTraceLimit'] = Infinity;
   require('zone.js/dist/long-stack-trace-zone');
 }
-
-(function () {
-  function CustomEvent ( event, params ) {
-    params = params || { bubbles: false, cancelable: false, detail: undefined };
-    var evt:CustomEvent = <any>document.createEvent( 'CustomEvent' );
-    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
-    return evt;
-   };
-
-  CustomEvent.prototype = Event.prototype;
-
-  (<any>window).CustomEvent = <any>CustomEvent;
-})();

--- a/src/e2e-app/tsconfig.json
+++ b/src/e2e-app/tsconfig.json
@@ -11,7 +11,7 @@
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "outDir": "../tmp/src",
-    "typeRoots": ["./../node_modules/@types"],
+    "typeRoots": ["../../node_modules/@types"],
     "types": [
       "node",
       "jasmine"


### PR DESCRIPTION
Each popover component was sending Events to close other popovers when opening. Since the `new Event('hide')` syntax is not supported in IE11, this change will increase cross-browser compatibility. Without this, you can get errors if a popover is expanded when another popover tries to expand. This would fix Issue #846 .