### PR TITLE
popover: added ability for user to specify position as for mdl-menu

### DIFF
--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -149,7 +149,7 @@ describe('MdlPopover', () => {
         });
     }));
 
-    it('should use user specified popover position', async(() => {
+    it('should use user specified popover position', async(async () => {
         let popoverComponent = fixture.debugElement.query(By.css('#positionPopover'));
         let popoverNativeElement = popoverComponent.nativeElement;
         let popoverComponentInstance = popoverComponent.componentInstance;
@@ -180,19 +180,34 @@ describe('MdlPopover', () => {
             .toEqual(true, 'toggle did not update isVisible to true');
 
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            expect(popoverNativeElement.classList.contains('is-visible'))
-                .toBe(true, 'did not has css class is-visible');
-        });
+        await fixture.whenStable();
+        expect(popoverNativeElement.classList.contains('is-visible'))
+            .toBe(true, 'did not has css class is-visible');
 
         spyOn(popoverComponentInstance, 'hide').and.callThrough();
         popoverComponentInstance.hide();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(popoverNativeElement.classList.contains('is-visible'))
+            .toBe(false, 'has not css class is-visible');
 
         const allOtherPositions = ['bottom-right', 'top-left', 'top-right', 'non-existent-one!'];
         for (const position of allOtherPositions) {
             popoverComponentInstance.position = position;
             buttonNativeElement.click();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(popoverNativeElement.classList.contains('is-visible'))
+                .toBe(true, 'did not has css class is-visible');
+
             popoverComponentInstance.hide();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(popoverNativeElement.classList.contains('is-visible'))
+                .toBe(false, 'has not css class is-visible');
         }
     }));
 });

--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -148,6 +148,43 @@ describe('MdlPopover', () => {
             expect(popoverComponentInstance.isVisible).toBe(false, 'main popover did not hide');
         });
     }));
+
+    it('should use user specified popover position', async(() => { 
+        let popoverComponent = fixture.debugElement.query(By.css('#positionPopover'));
+        let popoverNativeElement = popoverComponent.nativeElement;
+        let popoverComponentInstance = popoverComponent.componentInstance;
+
+        let buttonNativeElement = fixture.debugElement.query(By.css('#positionPopoverButton')).nativeElement; 
+
+        expect(popoverComponentInstance.isVisible)
+            .toEqual(false, 'isVisible is not false');
+
+        expect(popoverNativeElement.classList.contains('is-visible'))
+            .toBe(false, 'has not css class is-visible');
+
+        spyOn(popoverComponentInstance, 'toggle').and.callThrough();
+
+        spyOn(popoverComponentInstance, 'hideAllPopovers').and.callThrough();
+
+        spyOn(popoverComponentInstance, 'updateDirection').and.callThrough();
+
+        buttonNativeElement.click();
+
+        expect(popoverComponentInstance.toggle).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.hideAllPopovers).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.updateDirection).toHaveBeenCalled();
+
+        expect(popoverComponentInstance.isVisible)
+            .toEqual(true, 'toggle did not update isVisible to true');
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            expect(popoverNativeElement.classList.contains('is-visible'))
+                .toBe(true, 'did not has css class is-visible');
+        });
+    }));
 });
 
 @Component({
@@ -158,6 +195,9 @@ describe('MdlPopover', () => {
 
       <button (click)="anotherPopover.toggle($event)" id="anotherButton">button</button>
       <mdl-popover id="anotherPopover" #anotherPopover>fubar</mdl-popover>
+
+      <button id="positionPopoverButton" #positionPopoverButton (click)="positionPopover.toggle($event, positionPopoverButton)">button</button>
+      <mdl-popover id="positionPopover" #positionPopover mdl-popover-position="bottom-left">popover with position set</mdl-popover>
     `
 })
 class TestComponent {}

--- a/src/components/popover/popover.spec.ts
+++ b/src/components/popover/popover.spec.ts
@@ -13,7 +13,7 @@ describe('MdlPopover', () => {
             declarations: [TestComponent],
         });
 
-        TestBed.compileComponents().then( () => {
+        TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(TestComponent);
             fixture.detectChanges();
         });
@@ -61,10 +61,10 @@ describe('MdlPopover', () => {
         let popoverComponentInstance = popoverComponent.componentInstance;
 
         expect(popoverComponentInstance.isVisible)
-          .toEqual(false, 'isVisible is not false');
+            .toEqual(false, 'isVisible is not false');
 
         expect(popoverNativeElement.classList.contains('is-visible'))
-          .toBe(false, 'did has css class is-visible');
+            .toBe(false, 'did has css class is-visible');
 
         spyOn(popoverComponentInstance, 'toggle').and.callThrough();
 
@@ -89,13 +89,13 @@ describe('MdlPopover', () => {
         expect(popoverComponentInstance.updateDirection).toHaveBeenCalled();
 
         expect(popoverComponentInstance.isVisible)
-          .toEqual(true, 'toggle did not update isVisible to true');
+            .toEqual(true, 'toggle did not update isVisible to true');
 
         fixture.detectChanges();
         fixture.whenStable().then(() => {
 
             expect(popoverNativeElement.classList.contains('is-visible'))
-              .toBe(true, 'did not has css class is-visible');
+                .toBe(true, 'did not has css class is-visible');
         });
     }));
 
@@ -109,10 +109,10 @@ describe('MdlPopover', () => {
         let anotherPopoverComponentInstance = fixture.debugElement.query(By.css('#anotherPopover')).componentInstance;
 
         expect(popoverComponentInstance.isVisible)
-          .toEqual(false, 'isVisible is not false');
+            .toEqual(false, 'isVisible is not false');
 
         expect(popoverNativeElement.classList.contains('is-visible'))
-          .toBe(false, 'did has css class is-visible');
+            .toBe(false, 'did has css class is-visible');
 
         spyOn(popoverComponentInstance, 'toggle').and.callThrough();
 
@@ -129,13 +129,13 @@ describe('MdlPopover', () => {
         expect(popoverComponentInstance.updateDirection).toHaveBeenCalled();
 
         expect(popoverComponentInstance.isVisible)
-          .toEqual(true, 'toggle did not update isVisible to true');
+            .toEqual(true, 'toggle did not update isVisible to true');
 
         fixture.detectChanges();
         fixture.whenStable().then(() => {
 
             expect(popoverNativeElement.classList.contains('is-visible'))
-              .toBe(true, 'did not has css class is-visible');
+                .toBe(true, 'did not has css class is-visible');
         });
 
         let hideAllPopoversSpy = spyOn(anotherPopoverComponentInstance, 'hideAllPopovers').and.callThrough();
@@ -149,12 +149,12 @@ describe('MdlPopover', () => {
         });
     }));
 
-    it('should use user specified popover position', async(() => { 
+    it('should use user specified popover position', async(() => {
         let popoverComponent = fixture.debugElement.query(By.css('#positionPopover'));
         let popoverNativeElement = popoverComponent.nativeElement;
         let popoverComponentInstance = popoverComponent.componentInstance;
 
-        let buttonNativeElement = fixture.debugElement.query(By.css('#positionPopoverButton')).nativeElement; 
+        let buttonNativeElement = fixture.debugElement.query(By.css('#positionPopoverButton')).nativeElement;
 
         expect(popoverComponentInstance.isVisible)
             .toEqual(false, 'isVisible is not false');
@@ -184,6 +184,16 @@ describe('MdlPopover', () => {
             expect(popoverNativeElement.classList.contains('is-visible'))
                 .toBe(true, 'did not has css class is-visible');
         });
+
+        spyOn(popoverComponentInstance, 'hide').and.callThrough();
+        popoverComponentInstance.hide();
+
+        const allOtherPositions = ['bottom-right', 'top-left', 'top-right', 'non-existent-one!'];
+        for (const position of allOtherPositions) {
+            popoverComponentInstance.position = position;
+            buttonNativeElement.click();
+            popoverComponentInstance.hide();
+        }
     }));
 });
 
@@ -200,4 +210,4 @@ describe('MdlPopover', () => {
       <mdl-popover id="positionPopover" #positionPopover mdl-popover-position="bottom-left">popover with position set</mdl-popover>
     `
 })
-class TestComponent {}
+class TestComponent { }

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -14,6 +14,7 @@ import {
     ViewEncapsulation,
 } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
+import { MdlButtonComponent } from '@angular-mdl/core';
 
 @Injectable()
 export class MdlPopoverRegistry {
@@ -36,11 +37,70 @@ export class MdlPopoverRegistry {
     }
 
     public hideAllExcept(popoverComponent: MdlPopoverComponent) {
-        this.popoverComponents.forEach( (component) => {
+        this.popoverComponents.forEach((component) => {
             if (component !== popoverComponent) {
                 component.hide();
             }
         });
+    }
+}
+
+const BOTTOM_LEFT = 'bottom-left'; // Below the element, aligned to its left.
+const BOTTOM_RIGHT = 'bottom-right'; // Below the element, aligned to its right.
+const TOP_LEFT = 'top-left'; // Above the element, aligned to its left.
+const TOP_RIGHT = 'top-right'; // Above the element, aligned to its right.
+
+interface IPositionCoordinates {
+    left: number;
+    top: number;
+}
+
+@Injectable()
+export class PopupPositionService {
+    public applyCoordinates(coordinates: IPositionCoordinates, elementStyle: CSSStyleDeclaration) {
+        if (!coordinates) {
+            return;
+        }
+
+        elementStyle.right =
+            elementStyle.bottom = '';
+
+        for (const propertyName in coordinates) {
+            if (!coordinates.hasOwnProperty(propertyName)) {
+                continue;
+            }
+            const value = coordinates[propertyName];
+            elementStyle[propertyName] = value ? value + 'px' : '';
+        }
+    }
+
+    public calculateCoordinates(forElement: HTMLElement, popoverElement: HTMLElement, position: string): IPositionCoordinates {
+        if (!forElement || !position) {
+            return null;
+        }
+
+        switch (position) {
+            case BOTTOM_RIGHT:
+                return {
+                    top: forElement.offsetTop + forElement.offsetHeight,
+                    left: forElement.offsetLeft + forElement.offsetWidth - popoverElement.offsetWidth
+                };
+            case BOTTOM_LEFT:
+                return {
+                    top: forElement.offsetTop + forElement.offsetHeight,
+                    left: forElement.offsetLeft
+                };
+            case TOP_LEFT:
+                return {
+                    top: forElement.offsetTop - popoverElement.offsetHeight,
+                    left: forElement.offsetLeft
+                };
+            case TOP_RIGHT:
+                return {
+                    top: forElement.offsetTop - popoverElement.offsetHeight,
+                    left: forElement.offsetLeft + forElement.offsetWidth - popoverElement.offsetWidth
+                };
+        }
     }
 }
 
@@ -55,6 +115,7 @@ export class MdlPopoverRegistry {
 })
 export class MdlPopoverComponent {
     @Input('hide-on-click') public hideOnClick: boolean = false;
+    @Input('mdl-popover-position') public position: string;
     @Output() onShow: EventEmitter<any> = new EventEmitter();
     @Output() onHide: EventEmitter<any> = new EventEmitter();
     @HostBinding('class.is-visible') public isVisible = false;
@@ -66,20 +127,21 @@ export class MdlPopoverComponent {
     }
 
     constructor(private changeDetectionRef: ChangeDetectorRef,
-                public elementRef: ElementRef,
-                private popoverRegistry: MdlPopoverRegistry) {
+        public elementRef: ElementRef,
+        private popoverRegistry: MdlPopoverRegistry,
+        private popupPositionService: PopupPositionService) {
         this.popoverRegistry.add(this);
     }
 
     public ngOnDestroy() {
-       this.popoverRegistry.remove(this);
+        this.popoverRegistry.remove(this);
     }
 
-    public toggle(event: Event) {
+    public toggle(event: Event, forElement: any = null) {
         if (this.isVisible) {
             this.hide();
         } else {
-            this.show(event);
+            this.show(event, forElement);
         }
     }
 
@@ -95,41 +157,62 @@ export class MdlPopoverComponent {
         this.popoverRegistry.hideAllExcept(this);
     }
 
-    public show(event: Event) {
+    public show(event: Event, forElement: any = null) {
         this.hideAllPopovers();
         event.stopPropagation();
         if (!this.isVisible) {
             this.onShow.emit(null);
             this.isVisible = true;
-            this.updateDirection(event);
+            this.updateDirection(event, forElement);
         }
     }
 
-    private updateDirection(event: Event) {
-        const nativeEl = this.elementRef.nativeElement;
+    private updateDirection(event: Event, forElement: any = null) {
+        const popoverElement = this.elementRef.nativeElement;
         const targetRect = (<HTMLElement>event.target).getBoundingClientRect();
         const viewHeight = window.innerHeight;
 
         setTimeout(() => {
-            let height = nativeEl.offsetHeight;
+            if (forElement && this.position) {
+                const forHtmlElement = this.getHtmlElement(forElement);
+                const coordinates = this.popupPositionService.calculateCoordinates(forHtmlElement, popoverElement, this.position);
+                this.popupPositionService.applyCoordinates(coordinates, popoverElement.style);
+
+                this.changeDetectionRef.markForCheck();
+                // since we have user specified directions maybe it's better to let user to decide when and where the popup should be directed at?
+                // my point: we should not use the following code with "auto dirrection up"
+                return;
+            }
+
+            const height = popoverElement.offsetHeight;
             if (height) {
-                const spaceAvailable = {
-                    top: targetRect.top,
-                    bottom: viewHeight - targetRect.bottom
-                };
-                this.directionUp = spaceAvailable.bottom < height;
+                const bottomSpaceAvailable = viewHeight - targetRect.bottom
+                this.directionUp = bottomSpaceAvailable < height;
                 this.changeDetectionRef.markForCheck();
             }
         });
     }
-}
 
+    private getHtmlElement(forElement: any): HTMLElement {
+        if (forElement instanceof MdlButtonComponent) {
+            const buttonComponent = <MdlButtonComponent>forElement;
+            return buttonComponent.elementRef.nativeElement;
+        }
+
+        if (forElement instanceof ElementRef) {
+            const elementRef = <ElementRef>forElement;
+            return elementRef.nativeElement;
+        }
+
+        return forElement;
+    }
+}
 
 @NgModule({
     imports: [],
     exports: [MdlPopoverComponent],
     declarations: [MdlPopoverComponent],
-    providers: [MdlPopoverRegistry],
+    providers: [MdlPopoverRegistry, PopupPositionService],
 })
 export class MdlPopoverModule {
     static forRoot(): ModuleWithProviders {

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -57,6 +57,11 @@ export interface IPositionCoordinates {
 
 @Injectable()
 export class PopupPositionService {
+    public updatePosition(forElement: HTMLElement, popoverElement: HTMLElement, position: string): void {
+        const coordinates = this.calculateCoordinates(forElement, popoverElement, position);
+        this.applyCoordinates(coordinates, popoverElement.style);
+    }
+
     public applyCoordinates(coordinates: IPositionCoordinates, elementStyle: CSSStyleDeclaration) {
         if (!coordinates) {
             return;
@@ -167,12 +172,16 @@ export class MdlPopoverComponent {
         const targetRect = (<HTMLElement>event.target).getBoundingClientRect();
         const viewHeight = window.innerHeight;
 
-        setTimeout(() => {
-            if (forElement && this.position) {
-                const forHtmlElement = this.getHtmlElement(forElement);
-                const coordinates = this.popupPositionService.calculateCoordinates(forHtmlElement, popoverElement, this.position);
-                this.popupPositionService.applyCoordinates(coordinates, popoverElement.style);
+        const positionUpdateRequired = forElement && this.position;
+        if (positionUpdateRequired) {
+            popoverElement.style.visibility = 'hidden';
+        }
 
+        setTimeout(() => {
+            if (positionUpdateRequired) {
+                const forHtmlElement = this.getHtmlElement(forElement);
+                this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);      
+                popoverElement.style.visibility = 'visible';
                 this.changeDetectionRef.markForCheck();
                 // since we have user specified directions maybe it's better to let user to decide when and where the popup should be directed at?
                 // my point: we should not use the following code with "auto dirrection up"

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -50,7 +50,7 @@ const BOTTOM_RIGHT = 'bottom-right'; // Below the element, aligned to its right.
 const TOP_LEFT = 'top-left'; // Above the element, aligned to its left.
 const TOP_RIGHT = 'top-right'; // Above the element, aligned to its right.
 
-interface IPositionCoordinates {
+export interface IPositionCoordinates {
     left: number;
     top: number;
 }
@@ -65,13 +65,8 @@ export class PopupPositionService {
         elementStyle.right =
             elementStyle.bottom = '';
 
-        for (const propertyName in coordinates) {
-            if (!coordinates.hasOwnProperty(propertyName)) {
-                continue;
-            }
-            const value = coordinates[propertyName];
-            elementStyle[propertyName] = value ? value + 'px' : '';
-        }
+        elementStyle.left = coordinates.left + 'px';
+        elementStyle.top = coordinates.top + 'px';
     }
 
     public calculateCoordinates(forElement: HTMLElement, popoverElement: HTMLElement, position: string): IPositionCoordinates {

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -62,7 +62,7 @@ export class PopupPositionService {
         this.applyCoordinates(coordinates, popoverElement.style);
     }
 
-    public applyCoordinates(coordinates: IPositionCoordinates, elementStyle: CSSStyleDeclaration) {
+    private applyCoordinates(coordinates: IPositionCoordinates, elementStyle: CSSStyleDeclaration) {
         if (!coordinates) {
             return;
         }
@@ -74,7 +74,7 @@ export class PopupPositionService {
         elementStyle.top = coordinates.top + 'px';
     }
 
-    public calculateCoordinates(forElement: HTMLElement, popoverElement: HTMLElement, position: string): IPositionCoordinates {
+    private calculateCoordinates(forElement: HTMLElement, popoverElement: HTMLElement, position: string): IPositionCoordinates {
         if (!forElement || !position) {
             return null;
         }

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -68,7 +68,7 @@ export class PopupPositionService {
         }
 
         elementStyle.right =
-            elementStyle.bottom = '';
+        elementStyle.bottom = '';
 
         elementStyle.left = coordinates.left + 'px';
         elementStyle.top = coordinates.top + 'px';
@@ -169,8 +169,6 @@ export class MdlPopoverComponent {
 
     private updateDirection(event: Event, forElement: any = null) {
         const popoverElement = this.elementRef.nativeElement;
-        const targetRect = (<HTMLElement>event.target).getBoundingClientRect();
-        const viewHeight = window.innerHeight;
 
         const positionUpdateRequired = forElement && this.position;
         if (positionUpdateRequired) {
@@ -180,7 +178,7 @@ export class MdlPopoverComponent {
         setTimeout(() => {
             if (positionUpdateRequired) {
                 const forHtmlElement = this.getHtmlElement(forElement);
-                this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);      
+                this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);
                 popoverElement.style.visibility = 'visible';
                 this.changeDetectionRef.markForCheck();
                 // since we have user specified directions maybe it's better to let user to decide when and where the popup should be directed at?
@@ -188,6 +186,8 @@ export class MdlPopoverComponent {
                 return;
             }
 
+            const targetRect = (<HTMLElement>event.target).getBoundingClientRect();
+            const viewHeight = window.innerHeight;
             const height = popoverElement.offsetHeight;
             if (height) {
                 const bottomSpaceAvailable = viewHeight - targetRect.bottom

--- a/src/e2e-app/app/popover/popover.component.html
+++ b/src/e2e-app/app/popover/popover.component.html
@@ -43,6 +43,111 @@
   ]]>
 </pre>
 
+<h5>Custom popover with user specified position</h5>
+
+<div class="mdl-grid">
+  <div class="mdl-cell mdl-cell--3-col">
+     <div class="container" mdl-shadow="2">
+        <div class="bar mdl-color--primary">
+          <button #bottomLeftButton mdl-button (click)="bottomLeftPopover.toggle($event, bottomLeftButton)" mdl-button-type="icon" mdl-ripple>
+            <mdl-icon>more_vert</mdl-icon>
+          </button>
+          
+          <mdl-popover #bottomLeftPopover mdl-popover-position="bottom-left" [hide-on-click]="true" [style.width.px]="300">
+            <div mdl-shadow="6" style="padding: 1rem;">
+              <b>This is example popover</b> you can put any HTML content here.
+            </div>
+          </mdl-popover>
+        </div>
+        <div class="background"></div>
+     </div>
+  </div>
+  <div class="mdl-cell mdl-cell--3-col">
+     <div class="container" mdl-shadow="2">
+        <div class="bar mdl-color--primary">
+           <div class="top-right">
+            <button #bottomRightButton mdl-button (click)="bottomRightPopover.toggle($event, bottomRightButton)" mdl-button-type="icon" mdl-ripple>
+              <mdl-icon>more_vert</mdl-icon>
+            </button>    
+            <mdl-popover #bottomRightPopover mdl-popover-position="bottom-right" [hide-on-click]="true" [style.width.px]="300">
+              <div mdl-shadow="6" style="padding: 1rem;">
+                <b>This is example popover</b> you can put any HTML content here.
+              </div>
+            </mdl-popover>
+           </div>
+        </div>
+        <div class="background"></div>
+     </div>
+  </div>
+  <div class="mdl-cell mdl-cell--3-col">
+     <div class="container" mdl-shadow="2">
+        <div class="background"></div>
+        <div class="bar mdl-color--primary">
+          <button #topLeftButton mdl-button (click)="topLeftPopover.toggle($event, topLeftButton)" mdl-button-type="icon" mdl-ripple>
+            <mdl-icon>more_vert</mdl-icon>
+          </button>     
+          <mdl-popover #topLeftPopover mdl-popover-position="top-left" [hide-on-click]="true" [style.width.px]="300">
+            <div mdl-shadow="6" style="padding: 1rem;">
+              <b>This is example popover</b> you can put any HTML content here.
+            </div>
+          </mdl-popover>
+        </div>
+     </div>
+  </div>
+  <div class="mdl-cell mdl-cell--3-col">
+     <div class="container" mdl-shadow="2">
+        <div class="background"></div>
+        <div class="bar mdl-color--primary">
+           <div class="top-right">
+            <button #topRightButton mdl-button (click)="topRightPopover.toggle($event, topRightButton)" mdl-button-type="icon" mdl-ripple>
+              <mdl-icon>more_vert</mdl-icon>
+            </button>         
+            <mdl-popover #topRightPopover mdl-popover-position="top-right" [hide-on-click]="true" [style.width.px]="300">
+              <div mdl-shadow="6" style="padding: 1rem;">
+                <b>This is example popover</b> you can put any HTML content here.
+              </div>
+            </mdl-popover>
+           </div>
+        </div>
+     </div>
+  </div>
+</div>
+
+<pre prism>
+  <![CDATA[
+  <button #bottomLeftButton mdl-button (click)="bottomLeftPopover.toggle($event, bottomLeftButton)" mdl-button-type="icon" mdl-ripple><mdl-icon>more_vert</mdl-icon></button>
+  <mdl-popover #bottomLeftPopover mdl-popover-position="bottom-left" [hide-on-click]="true" [style.width.px]="300">
+    ...
+  </mdl-popover>
+  ]]>
+</pre>
+
+<pre prism>
+  <![CDATA[
+  <button #bottomRightButton mdl-button (click)="bottomRightPopover.toggle($event, bottomRightButton)" mdl-button-type="icon" mdl-ripple><mdl-icon>more_vert</mdl-icon></button>  
+  <mdl-popover #bottomRightPopover mdl-popover-position="bottom-right" [hide-on-click]="true" [style.width.px]="300">
+    ...
+  </mdl-popover>
+  ]]>
+</pre>
+
+<pre prism>
+  <![CDATA[
+  <button #topLeftButton mdl-button (click)="topLeftPopover.toggle($event, topLeftButton)" mdl-button-type="icon" mdl-ripple><mdl-icon>more_vert</mdl-icon></button> 
+  <mdl-popover #topLeftPopover mdl-popover-position="top-left" [hide-on-click]="true" [style.width.px]="300">
+    ...
+  </mdl-popover>
+  ]]>
+</pre>
+
+<pre prism>
+  <![CDATA[
+  <button #topRightButton mdl-button (click)="topRightPopover.toggle($event, topRightButton)" mdl-button-type="icon" mdl-ripple><mdl-icon>more_vert</mdl-icon></button>         
+  <mdl-popover #topRightPopover mdl-popover-position="top-right" [hide-on-click]="true" [style.width.px]="300">
+    ...
+  </mdl-popover>
+  ]]>
+</pre>
 
 <h5>Card popover</h5>
 

--- a/src/e2e-app/app/popover/popover.component.ts
+++ b/src/e2e-app/app/popover/popover.component.ts
@@ -10,7 +10,39 @@ import {
 @Component({
   selector: 'popover-demo',
   templateUrl: 'popover.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [
+    `
+     :host {
+        flex-grow: 1;
+     }
+     .container {
+        width:200px;
+        height: 212px;
+        position: relative;
+        margin: auto;
+     }
+     .bar {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 16px;
+        height: 64px;
+     }
+     .bar button {
+        color: white;
+     }
+     .top-right{
+        position:absolute;
+        box-sizing: border-box;
+        right: 16px;
+     }
+     .background {
+        background: white;
+        height: 148px;
+        width: 100%;
+     }
+    `
+  ]
 })
 export class PopoverDemo {
     onShow() {


### PR DESCRIPTION
-added ability for user to specify popover position using [mdl-popover-position] attribute which can take the following values: 'bottom-left', 'bottom-right', 'top-left', 'top-right'
-added some examples with different popover positions to e2e demo app:
<img width="1078" alt="screen shot 2017-10-08 at 10 44 44 pm" src="https://user-images.githubusercontent.com/5488533/31320258-6208c254-ac7a-11e7-9696-9ab95fe73eeb.png">
