### PR TITLE
popover: get rid of flickering for mdl-select and .direction-up

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -170,19 +170,14 @@ export class MdlPopoverComponent {
     private updateDirection(event: Event, forElement: any = null) {
         const popoverElement = this.elementRef.nativeElement;
 
-        const positionUpdateRequired = forElement && this.position;
-        if (positionUpdateRequired) {
-            popoverElement.style.visibility = 'hidden';
-        }
+        popoverElement.style.visibility = 'hidden';
 
         setTimeout(() => {
-            if (positionUpdateRequired) {
+            if (forElement && this.position) {
                 const forHtmlElement = this.getHtmlElement(forElement);
                 this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);
                 popoverElement.style.visibility = 'visible';
                 this.changeDetectionRef.markForCheck();
-                // since we have user specified directions maybe it's better to let user to decide when and where the popup should be directed at?
-                // my point: we should not use the following code with "auto dirrection up"
                 return;
             }
 
@@ -192,6 +187,7 @@ export class MdlPopoverComponent {
             if (height) {
                 const bottomSpaceAvailable = viewHeight - targetRect.bottom
                 this.directionUp = bottomSpaceAvailable < height;
+                popoverElement.style.visibility = 'visible';
                 this.changeDetectionRef.markForCheck();
             }
         });


### PR DESCRIPTION
Currently when we open mdl-select component that positioned at the bottom of the screen (so the drop-down items do not have enough space available) it will be opened with "up direction".

If you open the drop-down first time it will be opened with some noticeable flickering as it first will be rendered initially (top -> down) and only then with "up direction" (bottom -> up).

This small update fixes the issue

Popover with "up direction" example:
![image](https://user-images.githubusercontent.com/5488533/31769914-3477056e-b4de-11e7-85b6-06d7d7303636.png)
