### PR TITLE
popover: fix duplication of the popover styles in the resulted css bundle

### DIFF
--- a/src/components/popover/_variables.scss
+++ b/src/components/popover/_variables.scss
@@ -1,0 +1,3 @@
+@import "~@angular-mdl/core/scss/variables";
+$input-text-focus-border-width: 2px;
+$popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-focus-border-width;

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -1,4 +1,4 @@
-@import "../../../node_modules/@angular-mdl/core/scss/variables";
+@import "./variables";
 $input-text-focus-border-width: 2px;
 $popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-focus-border-width;
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,6 +1,5 @@
-@import "../../../node_modules/@angular-mdl/core/scss/variables";
-
-@import "../popover/popover";
+@import "~@angular-mdl/core/scss/variables";
+@import "../popover/variables";
 
 .mdl-select {
   &--floating-label {


### PR DESCRIPTION
Currently we have the duplication of the popover styles in the resulted css bundle:
![image](https://user-images.githubusercontent.com/5488533/31771110-84a751ce-b4e3-11e7-982b-ee85d54db885.png)

This happens because in mdl-select component we import the entire popover style set ('popover/popover.scss') but we actually need the popover variables.

How the issue fixed now:
-added popover variables as separated file - popover/variables.scss
-in [mdl-select] started importing that 'popover/variables.scss' instead of importing entire popover style set