### PR TITLE
[popover] start using visibility + moved 'auto directionUp' feature into select component level

### DIFF
--- a/src/components/popover/_variables.scss
+++ b/src/components/popover/_variables.scss
@@ -1,3 +1,0 @@
-@import "../../../node_modules/@angular-mdl/core/scss/variables";
-$input-text-focus-border-width: 2px;
-$popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-focus-border-width;

--- a/src/components/popover/popover.scss
+++ b/src/components/popover/popover.scss
@@ -1,11 +1,8 @@
-@import "./variables";
-$input-text-focus-border-width: 2px;
-$popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-focus-border-width;
-
 .mdl-popover {
   background: #fff;
   border: none;
-  display: none;
+  display: block;
+  visibility: hidden;
   margin: 0;
   overflow: visible;
   padding: 0;
@@ -13,10 +10,7 @@ $popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-
 
   &.is-visible,
   &.is-animating {
-    display: block;
+    visibility: visible;
     z-index: 999;
-  }
-  &.direction-up {
-    bottom: $popover-direction-up-bottom-offset;
   }
 }

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -119,7 +119,6 @@ export class MdlPopoverComponent {
     @Output() onShow: EventEmitter<any> = new EventEmitter();
     @Output() onHide: EventEmitter<any> = new EventEmitter();
     @HostBinding('class.is-visible') public isVisible = false;
-    @HostBinding('class.direction-up') public directionUp = false;
     @HostListener('click', ['$event']) onClick(event: Event) {
         if (!this.hideOnClick) {
             event.stopPropagation();
@@ -167,30 +166,15 @@ export class MdlPopoverComponent {
         }
     }
 
-    private updateDirection(event: Event, forElement: any = null) {
-        const popoverElement = this.elementRef.nativeElement;
-
-        popoverElement.style.visibility = 'hidden';
-
-        setTimeout(() => {
-            if (forElement && this.position) {
-                const forHtmlElement = this.getHtmlElement(forElement);
-                this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);
-                popoverElement.style.visibility = 'visible';
-                this.changeDetectionRef.markForCheck();
-                return;
-            }
-
-            const targetRect = (<HTMLElement>event.target).getBoundingClientRect();
-            const viewHeight = window.innerHeight;
-            const height = popoverElement.offsetHeight;
-            if (height) {
-                const bottomSpaceAvailable = viewHeight - targetRect.bottom
-                this.directionUp = bottomSpaceAvailable < height;
-                popoverElement.style.visibility = 'visible';
-                this.changeDetectionRef.markForCheck();
-            }
-        });
+    private updateDirection(event: Event, forElement: any) {
+        if (forElement && this.position) {
+            const popoverElement = this.elementRef.nativeElement;
+            
+            const forHtmlElement = this.getHtmlElement(forElement);
+            this.popupPositionService.updatePosition(forHtmlElement, popoverElement, this.position);
+            this.changeDetectionRef.markForCheck();
+            return;
+        }
     }
 
     private getHtmlElement(forElement: any): HTMLElement {

--- a/src/components/select/select.html
+++ b/src/components/select/select.html
@@ -25,6 +25,7 @@
   <label class="mdl-textfield__label" [attr.for]="textfieldId">{{ label }}</label>
   <span class="mdl-textfield__error"></span>
   <mdl-popover #popover tabindex="-1"
+               [class.direction-up]="directionUp"
                [class.mdl-popover--above]="autocomplete"
                [hide-on-click]="!multiple"
                [style.width.%]="100">

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,4 +1,6 @@
-@import "../popover/variables";
+@import "~@angular-mdl/core/scss/variables";
+$input-text-focus-border-width: 2px;
+$popover-direction-up-bottom-offset: $input-text-vertical-spacing + $input-text-focus-border-width;
 
 .mdl-select {
   &--floating-label {
@@ -25,8 +27,9 @@
     }
   }
 
-  .mdl-popover.mdl-popover--above {
-    &.direction-up {
+  .mdl-popover.direction-up {
+    bottom: $popover-direction-up-bottom-offset;
+    &.mdl-popover--above {
       bottom: $popover-direction-up-bottom-offset + $input-text-vertical-spacing + $input-text-font-size + $input-text-padding * 2;
     }
   }


### PR DESCRIPTION
Currently popover component has 'auto directionUp' feature that is triggered when there is no available space at the bottom to fit popover component.
But this feature only works for popover that is a part of the host select component. For example here it is opened with 'directionUp' fine:
<img width="369" alt="screen shot 2017-10-29 at 5 25 01 pm" src="https://user-images.githubusercontent.com/5488533/32144708-31fb7156-bcce-11e7-8909-a742f0bad9ae.png">
But for the popover component itself this feature doesn't work at all. As a prove try to open 'Card popover' at the demo with small available space at the bottom:
<img width="605" alt="screen shot 2017-10-29 at 5 30 56 pm" src="https://user-images.githubusercontent.com/5488533/32144790-0b3ec92c-bccf-11e7-830c-2b335fcd5f58.png">
You will see that popover opens a lot higher on the page than we expect.
This is bad as the popover component users have to deal with it (override the applied '.direction-up' styles).

But now popover has 'user specified position' option available where user can specify one of the few available popover positions (bottom-left. top-left, ...). So the user is now able to check manually - does the popover fit the window, and if it does not he can change the popover position so it opens fine

So we actually don't need that 'auto directionUp' feature at the popover component level but we do need it at the select component level.
 
 
_______________________________

Change info:
[select]
-start managing 'direction-up' for the embedded popover
-moved here all the popover 'direction-up' related css styles
-removed a few unnecessary .toArray() calls

[popover]
-made popover visibility to be triggered by 'visibility' css property as in mdlMenu
-got rid of 'direction-up' functionality as we don't need it any more
-removed popover variables since we don't need them any more