### PR TITLE
Fix select popover width for narrow inputs

### DIFF
--- a/src/components/select/select.html
+++ b/src/components/select/select.html
@@ -27,7 +27,7 @@
   <mdl-popover #popover tabindex="-1"
                [class.mdl-popover--above]="autocomplete"
                [hide-on-click]="!multiple"
-               [style.width.%]="100">
+               [style.minWidth.%]="100">
     <div class="mdl-list mdl-shadow--6dp">
       <ng-content *ngIf="popoverComponent.isVisible"></ng-content>
     </div>


### PR DESCRIPTION
This PR fixes problem with selects that have smaller width and popover is cut to 100% of its width.
Screenshot before:
![before](https://user-images.githubusercontent.com/4476888/32163545-ef491338-bd5c-11e7-9b98-2f279b7a9c10.png)
and after:
![after](https://user-images.githubusercontent.com/4476888/32163549-f3a487be-bd5c-11e7-84ee-ee2c6e45d028.png)

